### PR TITLE
Adding the `view` method to view specific part of a table in convenience.

### DIFF
--- a/pyliferisk/lifecontingencies.py
+++ b/pyliferisk/lifecontingencies.py
@@ -72,6 +72,21 @@ class MortalityTable:
                 lx_g = self.lx[g]
                 self.ex.append(0.5 + sum(self.lx[g+1:-1]) / lx_g) #[g+1:-2] according notes from ucm
 
+    def view(self, start = 0, end = 10, var = 'lx'):
+        column  = {'qx': self.qx, 'lx': self.lx, 'dx': self.dx, 'ex': self.ex, 'nt': self.nt, \
+                   'Dx': self.Dx, 'Nx': self.Nx, 'Cx': self.Cx, 'Mx': self.Mx, 'nEx': self.nEx}
+        table_str = ''
+        index = start
+        if var == 'nt':
+            subs = 'index'
+        else:
+            subs = 'x'
+        for i in column[var][start:end+1]:
+            table_str += '[{}={}]  {}={}\n'.format(subs, index, var, i)
+            index += 1
+        print(table_str + 'Total number of rows for {} = {}'.format(var, len(column[var])))
+
+        
 class Actuarial:
     def __init__(self, l_x=[], q_x=[], nt=None, i=None, perc=100):
         self.lx = l_x
@@ -146,6 +161,21 @@ class Actuarial:
             for m in range(0, len(self.Cx)):
                 self.Mx.append(sum(self.Cx[m:-1])) # [m:-2] according notes from ucm
 
+    def view(self, start = 0, end = 10, var = 'lx'):
+        column  = {'qx': self.qx, 'lx': self.lx, 'dx': self.dx, 'ex': self.ex, 'nt': self.nt, \
+                   'Dx': self.Dx, 'Nx': self.Nx, 'Cx': self.Cx, 'Mx': self.Mx, 'nEx': self.nEx}
+        table_str = ''
+        index = start
+        if var == 'nt':
+            subs = 'index'
+        else:
+            subs = 'x'
+        for i in column[var][start:end+1]:
+            table_str += '[{}={}]  {}={}\n'.format(subs, index, var, i)
+            index += 1
+        print(table_str + 'Total number of rows for {} = {}'.format(var, len(column[var])))
+
+   
 # Actuarial notation -------------------
 def qx(mt,x):
     """ qx: Returns the probability that a life aged x dies before 1 year


### PR DESCRIPTION
Usage example : 
`MT = MortalityTable(nt=GKM95)`

-  `MT.view() #the default table is lx`
```
[x=0]  lx=100000.0
[x=1]  lx=100000.0
[x=2]  lx=100000.0
[x=3]  lx=100000.0
[x=4]  lx=100000.0
[x=5]  lx=100000.0
[x=6]  lx=100000.0
[x=7]  lx=100000.0
[x=8]  lx=100000.0
[x=9]  lx=100000.0
[x=10]  lx=100000.0
Total number of rows for lx = 122
```

- `MT.view(10, 15, var = 'qx')`
```
[x=10]  qx=0.0
[x=11]  qx=0.0
[x=12]  qx=0.0
[x=13]  qx=0.0
[x=14]  qx=0.0
[x=15]  qx=1.5785
Total number of rows for qx = 121
```

- `MT.view(50, 70, var = 'ex')`
```
[x=50]  ex=27.889458797448594
[x=51]  ex=27.00798244139383
[x=52]  ex=26.13477997494254
[x=53]  ex=25.270474407937538
[x=54]  ex=24.415655440624512
[x=55]  ex=23.570849837869176
[x=56]  ex=22.73651222814852
[x=57]  ex=21.913028273620245
[x=58]  ex=21.1007038287661
[x=59]  ex=20.299765908416006
[x=60]  ex=19.510356905525445
[x=61]  ex=18.732533050579036
[x=62]  ex=17.966262380150845
[x=63]  ex=17.211418521905504
[x=64]  ex=16.467772722529297
[x=65]  ex=15.734997534955152
[x=66]  ex=15.015369572349249
[x=67]  ex=14.312074683966186
[x=68]  ex=13.627710337236591
[x=69]  ex=12.964343151850526
[x=70]  ex=12.323552661951307
Total number of rows for ex = 121
```

Regards.