### PR TITLE
Changed the definition of the nt property in the classes MortalityTable and Actuarial

### DIFF
--- a/pyliferisk/__init__.py
+++ b/pyliferisk/__init__.py
@@ -43,8 +43,11 @@ class MortalityTable:
                 if end_val < 1000.0:
                     end_val = val * perc / 100
                     self.qx.append(end_val)
+            # Apply the percentage to all the values in the table, except 
+            # for the last one, so the table will keep the same number of rows as 
+            # the original table and the last probability will always be 1,000
             if perc != 100:
-                self.qx.append(1000)
+                self.qx[-1] = 1000
         if self.lx == []:
             self.lx = [100000.0]
             for val in self.qx:
@@ -111,8 +114,11 @@ class Actuarial:
                 if end_val < 1000.0:
                     end_val = val * perc / 100
                     self.qx.append(end_val)
+            # Apply the percentage to all the values in the table, except 
+            # for the last one, so the table will keep the same number of rows as 
+            # the original table and the last probability will always be 1,000
             if perc != 100:
-                self.qx.append(1000)
+                self.qx[-1] = 1000
         if self.lx == []:
             self.lx = [100000.0]
             for val in self.qx:


### PR DESCRIPTION
The last q[x] percentage in a mortality table should always be 1, since the number of survivors would be 0 within the next year, so I replaced "self.qx.append(1000)" by "self.qx[-1] = 1000".